### PR TITLE
feat: allow all origins in staging for now

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -39,7 +39,8 @@ database_id = "783a91d6-63ae-454b-8f26-ac015e862376"
 ALLOW_ORIGIN = "http://localhost:3004"
 
 [env.staging.vars] 
-ALLOW_ORIGIN = "https://staging.console.storacha.network"
+# set ALLOW_ORIGIN to * for now to let the service work with all the preview deployments which use random URLs
+ALLOW_ORIGIN = "*"
 
 [env.production.vars] 
 ALLOW_ORIGIN = "https://console.storacha.network"


### PR DESCRIPTION
at some point we may want to add some logic to manually set the "allow origin" header to the origin of the current request if it matches a regex, but for now just leave it wide open