### PR TITLE
fix: return 400s for client errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,12 +61,18 @@ export const refcodeCreate: RSRouterHandler = async function (
   const form = await req.formData()
   const email = form.get('email')?.toString()
   if (email) {
-    return Response.json({
-      refcode: await createRefcode(
-        env.REFERRALS,
-        email
-      )
-    })
+    try {
+      return Response.json({
+        refcode: await createRefcode(env.REFERRALS, email)
+      })
+    } catch (e: any) {
+      if (e.message === 'D1_ERROR: UNIQUE constraint failed: users.email: SQLITE_CONSTRAINT') {
+        return new Response('already created a referral for that email', { status: 400 })
+      } else {
+        console.error(e)
+        return new Response('unknown error, please check server logs', { status: 500 })
+      }
+    }
   } else {
     return new Response('invalid email', { status: 400 })
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,8 +31,17 @@ const referralCreate: RSRouterHandler = async function (
     if (email === referrerEmail) {
       return new Response('cannot refer  oneself', { status: 400 })
     } else {
-      await createReferral(env.REFERRALS, email, refcode)
-      return Response.json({})
+      try {
+        await createReferral(env.REFERRALS, email, refcode)
+        return Response.json({})
+      } catch (e: any) {
+        if (e.message === 'D1_ERROR: UNIQUE constraint failed: referrals.email: SQLITE_CONSTRAINT') {
+          return new Response('already created a referral for that email', { status: 400 })
+        } else {
+          console.error(e)
+          return new Response('unknown error, please check server logs', { status: 500 })
+        }
+      }
     }
   }
 }

--- a/test/http.spec.ts
+++ b/test/http.spec.ts
@@ -73,14 +73,24 @@ describe('the referral service', () => {
     const referredByResponse = await getReferredBy(newUserEmail)
     const referredByResponseJson = await referredByResponse.json() as any
     expect(referredByResponseJson).toHaveProperty('refcode')
+  });
 
-    // create a second referral
+  it('can create multiple referrals with the same refcode', async () => {
+
+    // create a refcode
+    const email = 'test@example.com'
+    const createRefcodeResponse = await createRefcode(email);
+    const refcode = (await createRefcodeResponse.json() as any).refcode as string
+
+    // create a referral
+    const newUserEmail = 'newuser@example.com'
+    await createReferral(refcode, newUserEmail)
     const secondNewUserEmail = 'secondnewuser@example.com'
     await createReferral(refcode, secondNewUserEmail);
 
     // now there should be two referrals
-    referralsResponse = await getReferrals(refcode)
-    referralsResponseJson = await referralsResponse.json() as any
+    const referralsResponse = await getReferrals(refcode)
+    const referralsResponseJson = await referralsResponse.json() as any
     expect(referralsResponseJson).toHaveProperty('referrals');
     expect(referralsResponseJson.referrals).toBeInstanceOf(Array);
     expect(referralsResponseJson.referrals).toHaveLength(2)
@@ -88,6 +98,44 @@ describe('the referral service', () => {
     const secondReferredByResponse = await getReferredBy(secondNewUserEmail)
     const secondReferredByResponseJson = await secondReferredByResponse.json() as any
     expect(secondReferredByResponseJson).toHaveProperty('refcode')
+  });
+
+  it('will not create a referral for an email that has already been referred', async () => {
+
+    // create a refcode
+    const email = 'test@example.com'
+    const createRefcodeResponse = await createRefcode(email);
+    const refcode = (await createRefcodeResponse.json() as any).refcode as string
+
+    // create a referral
+    const newUserEmail = 'newuser@example.com'
+    await createReferral(refcode, newUserEmail)
+
+    // creating a referral for the same refcode and email should 400
+    const sameRefcodeSameEmailResponse = await createReferral(refcode, newUserEmail);
+    expect(sameRefcodeSameEmailResponse.status).toBe(400)
+
+    // create a second refcode
+    const secondEmail = 'test2@example.com'
+    const secondCreateRefcodeResponse = await createRefcode(secondEmail);
+    const secondRefcode = (await secondCreateRefcodeResponse.json() as any).refcode as string
+
+    // creating a referral for a different refcode and but the same email should 400
+    const sameRefcodeDifferentEmailResponse = await createReferral(secondRefcode, newUserEmail);
+    expect(sameRefcodeDifferentEmailResponse.status).toBe(400)
+
+    // there should only be 1 referral
+    const referralsResponse = await getReferrals(refcode)
+    const referralsResponseJson = await referralsResponse.json() as any
+    expect(referralsResponseJson).toHaveProperty('referrals');
+    expect(referralsResponseJson.referrals).toBeInstanceOf(Array);
+    expect(referralsResponseJson.referrals).toHaveLength(1)
+
+    const referredByResponse = await getReferredBy(newUserEmail)
+    const secondReferredByResponseJson = await referredByResponse.json() as any
+    expect(secondReferredByResponseJson).toHaveProperty('refcode')
+    expect(secondReferredByResponseJson.refcode).toEqual(refcode)
+
   });
 
   it('will not create a referral for the user who created the refcode', async () => {

--- a/test/http.spec.ts
+++ b/test/http.spec.ts
@@ -39,10 +39,34 @@ describe('the referral service', () => {
   it('creates a refcode successfully', async () => {
     const email = 'test@example.com'
     const createResponse = await createRefcode(email)
-    expect(await createResponse.json()).toHaveProperty('refcode');
+    const createResult: any = await createResponse.json()
+    expect(createResult).toHaveProperty('refcode');
+    const refcodeFromCreate = createResult.refcode
 
     const getResponse = await getRefcode(email);
-    expect(await getResponse.json()).toHaveProperty('refcode');
+    const getResult: any = await getResponse.json()
+    expect(getResult).toHaveProperty('refcode');
+    const refcodeFromGet = getResult.refcode
+    expect(refcodeFromCreate).toEqual(refcodeFromGet)
+  });
+
+  it('will not create a second refcode for the same user', async () => {
+    const email = 'test@example.com'
+    const createResponse = await createRefcode(email)
+    const createResult: any = await createResponse.json()
+    expect(createResult).toHaveProperty('refcode');
+    const refcodeFromCreate = createResult.refcode
+
+    // trying to create a refcode a second time should fail
+    const create2Response = await createRefcode(email);
+    expect(create2Response.status).toBe(400)
+
+    // and the get response should match the first create
+    const getResponse = await getRefcode(email);
+    const getResult: any = await getResponse.json()
+    expect(getResult).toHaveProperty('refcode');
+    const refcodeFromGet = getResult.refcode
+    expect(refcodeFromCreate).toEqual(refcodeFromGet)
   });
 
   it('creates a referral successfully', async () => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -36,7 +36,7 @@ database_name = "referrals"
 database_id = "28f82ea3-8c6a-46ca-b832-17aaaa496a29"
 
 [vars]
-ALLOW_ORIGIN = "http://localhost:3004"
+ALLOW_ORIGIN = "http://localhost:3000"
 
 [env.staging.vars] 
 # set ALLOW_ORIGIN to * for now to let the service work with all the preview deployments which use random URLs


### PR DESCRIPTION
if a client tries to create a referral for an email that has already been referred, return a 400 so we can ignore that error in console